### PR TITLE
build multi-arch images for friendlier development on macos

### DIFF
--- a/.github/workflows/build-deployment-container.yml
+++ b/.github/workflows/build-deployment-container.yml
@@ -8,16 +8,22 @@ on:
   workflow_dispatch:
 jobs:
   docker:
-    runs-on: ubuntu-20.04
-    name: Docker Push
+    runs-on: ubuntu-22.04
+    name: Docker push deployment
     steps:
-      - uses: actions/checkout@v3
-      - name: docker build
-        run: docker build . -t metacpan/metacpan-base:$GITHUB_SHA
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: push build to Docker hub
-        run: docker push metacpan/metacpan-base:$GITHUB_SHA
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: metacpan/metacpan-base:$GITHUB_SHA
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build-production-container.yml
+++ b/.github/workflows/build-production-container.yml
@@ -10,13 +10,19 @@ jobs:
     runs-on: ubuntu-22.04
     name: Docker push deployment
     steps:
-      - uses: actions/checkout@v3
-      - name: docker build
-        run: docker build . -t metacpan/metacpan-base:latest
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+      - uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: push build to Docker hub
-        run: docker push metacpan/metacpan-base:latest
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: metacpan/metacpan-base:latest
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   docker:
     runs-on: ubuntu-22.04
-    name: Docker Push
+    name: Docker Test
     steps:
       - uses: actions/checkout@v3
       - name: docker build


### PR DESCRIPTION
Set up QEMU so builds can be done for other platforms. This allows building for arm64, which is nicer to have on mac systems.

Update the action versions and switch to using the docker provided actions for build and push.