### PR TITLE
new uwsgi settings

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,10 @@
+# https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 [uwsgi]
 master = true
 workers = 20
 die-on-term = true
+need-app = true
+vacuum = true
 
 disable-logging = true
 
@@ -11,3 +14,8 @@ buffer-size = 65535
 
 early-psgi = true
 perl-no-die-catch = true
+
+max-worker-lifetime = 3600
+max-requests = 1000
+reload-on-rss = 300
+harakiri = 60

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -19,3 +19,7 @@ max-worker-lifetime = 3600
 max-requests = 1000
 reload-on-rss = 300
 harakiri = 60
+
+if-file = /etc/uwsgi-extra.ini
+  ini = /etc/uwsgi-extra.ini
+endfor =


### PR DESCRIPTION
Enable some additional settings so worker processes get recycled periodically, so they won't grow to use too much memory.