### PR TITLE
remove logic for trying to use extra config files

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -19,7 +19,3 @@ max-worker-lifetime = 3600
 max-requests = 1000
 reload-on-rss = 300
 harakiri = 60
-
-if-file = /etc/uwsgi-extra.ini
-  ini = /etc/uwsgi-extra.ini
-endif =

--- a/uwsgi.sh
+++ b/uwsgi.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-pid="$$"
-uwsgi_ini="/etc/uwsgi.ini"
 
 if [[ "$PLACK_ENV" == "development" ]]; then
-    if [[ -e '/etc/uwsgi-development.ini' ]]; then
-        uwsgi_ini="/etc/uwsgi-development.ini"
-    fi
+    pid="$$"
     (
         set -m
         "$script_dir/watcher.sh" "$pid" lib *.conf &
@@ -17,6 +13,6 @@ fi
 exec /usr/bin/uwsgi \
     --plugins psgi \
     --http-socket-modifier1 5 \
-    --ini /etc/uwsgi.ini \
+    --ini "/etc/uwsgi.ini" \
     "$@" \
     --psgi app.psgi


### PR DESCRIPTION
The development config file never worked, and if you want to use an extra config file it can be easily be specified as a command line argument.