### PR TITLE
switch to reusable docker build action

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -11,53 +11,20 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     name: Docker build and push
-    strategy:
-      matrix:
-        slim: [ true, false ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - uses: metacpan/metacpan-actions/docker-build-push@master
+        id: build-push
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USER }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          ghcr_username: ${{ github.repository_owner }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: metacpan/metacpan-actions/docker-build-push@master
+        id: build-push
         with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            docker.io/${{ github.repository }}
-            ghcr.io/${{ github.repository }}
-          flavor: |
-            latest=false
-            ${{ matrix.slim && 'suffix=-slim' || '' }}
-          tags: |
-            type=sha,format=long,priority=2000,enable={{is_default_branch}}
-            type=raw,value={{branch}}-{{date 'YYYYMMDD-HHmmss'}},priority=1000,enable=${{ startsWith(github.ref, 'refs/heads/' ) }}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
-          build-args: |
-            ${{ matrix.slim && 'SLIM_BUILD=1' || '' }}
+          docker_hub_username: ${{ secrets.DOCKER_HUB_USER }}
+          docker_hub_password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          ghcr_username: ${{ github.repository_owner }}
+          ghcr_password: ${{ secrets.GITHUB_TOKEN }}
+          slim: true


### PR DESCRIPTION
This standardizes the way we do labels and tags, and make reuse much easier. The slim builds can be merged into the same set of steps so they should have everything cached and will run faster.